### PR TITLE
Better pseudotoplevel

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,9 +2,6 @@ import init, { eval_code } from "./scryer_prolog.js";
 
 let ready = false;
 
-const regex = /initialization\/1 failed for/g;
-
-
 window.onload = () => {
     const source = document.getElementById("source");
     const history = document.getElementById("history");
@@ -126,11 +123,7 @@ window.onload = () => {
 	    element.appendChild(historyQuery);
 	    const historyOutput = document.createElement("pre");
 	    historyOutput.className = "output";
-	    if(result.search(regex) == -1) {
-		historyOutput.textContent = result;
-	    } else {
-		historyOutput.textContent = "false.";
-	    }
+      historyOutput.textContent = result;
 	    element.appendChild(historyOutput);
 	    history.appendChild(element);
 	    element.scrollIntoView(false);


### PR DESCRIPTION
The answers to the queries now show all answers, shows non-determinism, and interleaves stdout just like the Scryer toplevel on a terminal. For the following program:

```
a(1).
a(2).
a(3).
a(4) :- write('test text'), nl.
a(_) :- false.
```

This is the old answer:
![image](https://github.com/aarroyoc/scryer-playground/assets/58273945/27c0e2b6-b8a5-43c6-a778-2fc70e51fe56)

This is the new answer:
![image](https://github.com/aarroyoc/scryer-playground/assets/58273945/a06128d5-0e1a-427d-8399-1480d951e591)

The new answer is identical to what you see for the same program and query with Scryer in a terminal.

## Problem that still exist

- No interaction because of limitations of the Scryer WASM interface. It basically always works as if you pressed "a" in the terminal.
- Answers that have no variable bindings still list all variables anyway.
  ![image](https://github.com/aarroyoc/scryer-playground/assets/58273945/72441885-a8c7-4ab6-898a-1768b8996d41)
  (Expected `true.`)
- There are no residual goals for attributed variables.
  ![image](https://github.com/aarroyoc/scryer-playground/assets/58273945/1f6eea47-2b89-4cd0-b6e0-d5d8fd8383c9)
  (Expected `dif:dif(1,A).`)

I think all of these problems are much harder to solve, but also lower priority than just having multiple answers at all, and therefore can be done latter.

I think this closes #7.